### PR TITLE
Modify expected input

### DIFF
--- a/R/frbca.R
+++ b/R/frbca.R
@@ -42,18 +42,17 @@
 preprocess_model <- function(eal, cost, p) {
     ## Purpose:
     ## join eal and cost tables
-    ## compute height (floors) and total area
+    ## compute total floor area (floor area * num_stories)
     ## separate models by height
-    ## 
+    ##
     models <- list()
     dat <- eal %>%
-        dplyr::left_join(cost, by=c('model', 'intervention')) %>%
-        dplyr::mutate(total_floors=as.numeric(gsub('(.*-)(\\d{1,2})$', '\\2', model))) %>%
-        dplyr::mutate(total_area=p$floor_area*total_floors)
-    floors <- dat %>% dplyr::distinct(total_floors) %>% pull()
-    for (i in 1:length(floors)) {
+        dplyr::left_join(cost, by=c('model', 'intervention', 'num_stories')) %>%
+        dplyr::mutate(total_area=p$floor_area*num_stories)
+    stories <- dat %>% dplyr::distinct(num_stories) %>% pull()
+    for (i in 1:length(stories)) {
         models[[i]] <- dat %>%
-            dplyr::filter(total_floors == floors[i])
+            dplyr::filter(num_stories == stories[i])
     }
     return(models)
 }
@@ -284,7 +283,7 @@ frbca <- function(eal, cost, params) {
 plot_frbca <- function(output, n_floors=4, system='RCMF') {
   plot_df <- output %>%
     dplyr::filter(!is.na(bcr)) %>%
-    dplyr::filter(total_floors == n_floors) %>%
+    dplyr::filter(num_stories == n_floors) %>%
     dplyr::select(model, bcr, label, parameter)
   base <- plot_df %>%
     dplyr::filter(label == 'base') %>%

--- a/README.Rmd
+++ b/README.Rmd
@@ -37,12 +37,81 @@ You can install frbca from [GitHub](https://github.com) with:
 devtools::install_github("juanfung/frbca")
 ```
 
+## Expected inputs
+
+To run the analysis, provide two inputs in tabular (eg, `data.frame`) form:
+
+### Expected annualized losses (EALs) from a performance assessment
+
+Each row is an archetype model. Expected (minimum) columns:
+
+```
+| variable                 | type  | description                        |
+|--------------------------|-------|------------------------------------|
+| model                    | <chr> | unique model name or id            |
+| intervention             | {0,1} | baseline design = 0; otherwise = 1 |
+| num_stories              | <dbl> | number of stories                  |
+| loss_ratio               | <dbl> | loss ratio                         |
+| repair_costs             | <dbl> | repair costs, in dollars           |
+| re_occupancy_time        | <dbl> | re-occupancy time, in days         |
+| functional_recovery_time | <dbl> | functional recovery time, in days  |
+```
+
+### Construction costs, for each archetype
+
+Each row is an archetype model. Expected (minimum) columns:
+
+```
+| variable     | type  | description                                  |
+|--------------|-------|----------------------------------------------|
+| model        | <chr> | unique model name or id                      |
+| intervention | {0,1} | baseline design = 0; otherwise = 1           |
+| num_stories  | <dbl> | number of stories                            |
+| c_s          | <dbl> | structural construction costs, in dollars    |
+| c_ns         | <dbl> | nonstructural construction costs, in dollars |
+```
+
+
+In addition, several parameters are required in list form. The following are the
+base parameters required under sub-list `input_param$parameters$base`:
+
+```
+| parameter    | type    | description                                        |
+|--------------|---------|----------------------------------------------------|
+| floor_area   | <dbl>   | total square footage per story                     |
+| delta        | <delta> | discount rate                                      |
+| T            | <dbl>   | planning horizon, in years                         |
+| bi           | <dbl>   | business income                                    |
+| ri           | <dbl>   | rental income                                      |
+| displacement | <dbl>   | occupant-incurred costs of displacement            |
+| tenant       | <dbl>   | number of tenants per square foot                  |
+| recapture    | <dbl>   | recapture rate for rental income                   |
+| sc           | <sc>    | supply-chain multiplier for business income losses |
+```
+
+In addition, parameter values for sensitivity analysis should be provided under
+the sub-list `input_param$parameters$sensitivity`. For example, sensitivity
+analysis for `delta` would be conducted based on provided values
+`input_param$parameters$sensitivity$delta$low` and
+`input_param$parameters$sensitivity$delta$high`.
+
+
 ## Example
 
 This is a basic example which shows you how to solve a common problem:
 
-```{r example}
+```{r example, eval=FALSE}
+## NOT RUN
 library(frbca)
-## basic example code
+
+## assuming input data is loaded and parameters are set...
+
+## run analysis
+output <- frbca::frbca(input_eal, input_cost, input_param)
+
+## generate results plot with sensitivity analysis
+frbca::plot_frbca(output, n_floors=4, system='RCMF')
+
+
 ```
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -45,7 +45,7 @@ To run the analysis, provide two inputs in tabular (eg, `data.frame`) form:
 
 Each row is an archetype model. Expected (minimum) columns:
 
-
+```
 | variable                 | type  | description                        |
 |--------------------------|-------|------------------------------------|
 | model                    | <chr> | unique model name or id            |
@@ -55,13 +55,13 @@ Each row is an archetype model. Expected (minimum) columns:
 | repair_costs             | <dbl> | repair costs, in dollars           |
 | re_occupancy_time        | <dbl> | re-occupancy time, in days         |
 | functional_recovery_time | <dbl> | functional recovery time, in days  |
+```
 
-
-### Construction costs, for each archetype
+### Construction costs
 
 Each row is an archetype model. Expected (minimum) columns:
 
-
+```
 | variable     | type  | description                                  |
 |--------------|-------|----------------------------------------------|
 | model        | <chr> | unique model name or id                      |
@@ -69,13 +69,13 @@ Each row is an archetype model. Expected (minimum) columns:
 | num_stories  | <dbl> | number of stories                            |
 | c_s          | <dbl> | structural construction costs, in dollars    |
 | c_ns         | <dbl> | nonstructural construction costs, in dollars |
-
+```
 
 
 In addition, several parameters are required in list form. The following are the
 base parameters required under sub-list `input_param$parameters$base`:
 
-
+```
 | parameter    | type    | description                                        |
 |--------------|---------|----------------------------------------------------|
 | floor_area   | <dbl>   | total square footage per story                     |
@@ -87,7 +87,7 @@ base parameters required under sub-list `input_param$parameters$base`:
 | tenant       | <dbl>   | number of tenants per square foot                  |
 | recapture    | <dbl>   | recapture rate for rental income                   |
 | sc           | <sc>    | supply-chain multiplier for business income losses |
-
+```
 
 In addition, parameter values for sensitivity analysis should be provided under
 the sub-list `input_param$parameters$sensitivity`. For example, sensitivity

--- a/README.Rmd
+++ b/README.Rmd
@@ -45,7 +45,7 @@ To run the analysis, provide two inputs in tabular (eg, `data.frame`) form:
 
 Each row is an archetype model. Expected (minimum) columns:
 
-```
+
 | variable                 | type  | description                        |
 |--------------------------|-------|------------------------------------|
 | model                    | <chr> | unique model name or id            |
@@ -55,13 +55,13 @@ Each row is an archetype model. Expected (minimum) columns:
 | repair_costs             | <dbl> | repair costs, in dollars           |
 | re_occupancy_time        | <dbl> | re-occupancy time, in days         |
 | functional_recovery_time | <dbl> | functional recovery time, in days  |
-```
+
 
 ### Construction costs, for each archetype
 
 Each row is an archetype model. Expected (minimum) columns:
 
-```
+
 | variable     | type  | description                                  |
 |--------------|-------|----------------------------------------------|
 | model        | <chr> | unique model name or id                      |
@@ -69,13 +69,13 @@ Each row is an archetype model. Expected (minimum) columns:
 | num_stories  | <dbl> | number of stories                            |
 | c_s          | <dbl> | structural construction costs, in dollars    |
 | c_ns         | <dbl> | nonstructural construction costs, in dollars |
-```
+
 
 
 In addition, several parameters are required in list form. The following are the
 base parameters required under sub-list `input_param$parameters$base`:
 
-```
+
 | parameter    | type    | description                                        |
 |--------------|---------|----------------------------------------------------|
 | floor_area   | <dbl>   | total square footage per story                     |
@@ -87,7 +87,7 @@ base parameters required under sub-list `input_param$parameters$base`:
 | tenant       | <dbl>   | number of tenants per square foot                  |
 | recapture    | <dbl>   | recapture rate for rental income                   |
 | sc           | <sc>    | supply-chain multiplier for business income losses |
-```
+
 
 In addition, parameter values for sensitivity analysis should be provided under
 the sub-list `input_param$parameters$sensitivity`. For example, sensitivity

--- a/README.md
+++ b/README.md
@@ -35,43 +35,43 @@ form:
 
 Each row is an archetype model. Expected (minimum) columns:
 
-| variable                 | type  | description                        |
-|--------------------------|-------|------------------------------------|
-| model                    | <chr> | unique model name or id            |
-| intervention             | {0,1} | baseline design = 0; otherwise = 1 |
-| num_stories              | <dbl> | number of stories                  |
-| loss_ratio               | <dbl> | loss ratio                         |
-| repair_costs             | <dbl> | repair costs, in dollars           |
-| re_occupancy_time        | <dbl> | re-occupancy time, in days         |
-| functional_recovery_time | <dbl> | functional recovery time, in days  |
+    | variable                 | type  | description                        |
+    |--------------------------|-------|------------------------------------|
+    | model                    | <chr> | unique model name or id            |
+    | intervention             | {0,1} | baseline design = 0; otherwise = 1 |
+    | num_stories              | <dbl> | number of stories                  |
+    | loss_ratio               | <dbl> | loss ratio                         |
+    | repair_costs             | <dbl> | repair costs, in dollars           |
+    | re_occupancy_time        | <dbl> | re-occupancy time, in days         |
+    | functional_recovery_time | <dbl> | functional recovery time, in days  |
 
-### Construction costs, for each archetype
+### Construction costs
 
 Each row is an archetype model. Expected (minimum) columns:
 
-| variable     | type  | description                                  |
-|--------------|-------|----------------------------------------------|
-| model        | <chr> | unique model name or id                      |
-| intervention | {0,1} | baseline design = 0; otherwise = 1           |
-| num_stories  | <dbl> | number of stories                            |
-| c_s          | <dbl> | structural construction costs, in dollars    |
-| c_ns         | <dbl> | nonstructural construction costs, in dollars |
+    | variable     | type  | description                                  |
+    |--------------|-------|----------------------------------------------|
+    | model        | <chr> | unique model name or id                      |
+    | intervention | {0,1} | baseline design = 0; otherwise = 1           |
+    | num_stories  | <dbl> | number of stories                            |
+    | c_s          | <dbl> | structural construction costs, in dollars    |
+    | c_ns         | <dbl> | nonstructural construction costs, in dollars |
 
 In addition, several parameters are required in list form. The following
 are the base parameters required under sub-list
 `input_param$parameters$base`:
 
-| parameter    | type    | description                                        |
-|--------------|---------|----------------------------------------------------|
-| floor_area   | <dbl>   | total square footage per story                     |
-| delta        | <delta> | discount rate                                      |
-| T            | <dbl>   | planning horizon, in years                         |
-| bi           | <dbl>   | business income                                    |
-| ri           | <dbl>   | rental income                                      |
-| displacement | <dbl>   | occupant-incurred costs of displacement            |
-| tenant       | <dbl>   | number of tenants per square foot                  |
-| recapture    | <dbl>   | recapture rate for rental income                   |
-| sc           | <sc>    | supply-chain multiplier for business income losses |
+    | parameter    | type    | description                                        |
+    |--------------|---------|----------------------------------------------------|
+    | floor_area   | <dbl>   | total square footage per story                     |
+    | delta        | <delta> | discount rate                                      |
+    | T            | <dbl>   | planning horizon, in years                         |
+    | bi           | <dbl>   | business income                                    |
+    | ri           | <dbl>   | rental income                                      |
+    | displacement | <dbl>   | occupant-incurred costs of displacement            |
+    | tenant       | <dbl>   | number of tenants per square foot                  |
+    | recapture    | <dbl>   | recapture rate for rental income                   |
+    | sc           | <sc>    | supply-chain multiplier for business income losses |
 
 In addition, parameter values for sensitivity analysis should be
 provided under the sub-list `input_param$parameters$sensitivity`. For

--- a/README.md
+++ b/README.md
@@ -26,11 +26,72 @@ You can install frbca from [GitHub](https://github.com) with:
 devtools::install_github("juanfung/frbca")
 ```
 
+## Expected inputs
+
+To run the analysis, provide two inputs in tabular (eg, `data.frame`)
+form:
+
+### Expected annualized losses (EALs) from a performance assessment
+
+Each row is an archetype model. Expected (minimum) columns:
+
+    | variable                 | type  | description                        |
+    |--------------------------|-------|------------------------------------|
+    | model                    | <chr> | unique model name or id            |
+    | intervention             | {0,1} | baseline design = 0; otherwise = 1 |
+    | num_stories              | <dbl> | number of stories                  |
+    | loss_ratio               | <dbl> | loss ratio                         |
+    | repair_costs             | <dbl> | repair costs, in dollars           |
+    | re_occupancy_time        | <dbl> | re-occupancy time, in days         |
+    | functional_recovery_time | <dbl> | functional recovery time, in days  |
+
+### Construction costs, for each archetype
+
+Each row is an archetype model. Expected (minimum) columns:
+
+    | variable     | type  | description                                  |
+    |--------------|-------|----------------------------------------------|
+    | model        | <chr> | unique model name or id                      |
+    | intervention | {0,1} | baseline design = 0; otherwise = 1           |
+    | num_stories  | <dbl> | number of stories                            |
+    | c_s          | <dbl> | structural construction costs, in dollars    |
+    | c_ns         | <dbl> | nonstructural construction costs, in dollars |
+
+In addition, several parameters are required in list form. The following
+are the base parameters required under sub-list
+`input_param$parameters$base`:
+
+    | parameter    | type    | description                                        |
+    |--------------|---------|----------------------------------------------------|
+    | floor_area   | <dbl>   | total square footage per story                     |
+    | delta        | <delta> | discount rate                                      |
+    | T            | <dbl>   | planning horizon, in years                         |
+    | bi           | <dbl>   | business income                                    |
+    | ri           | <dbl>   | rental income                                      |
+    | displacement | <dbl>   | occupant-incurred costs of displacement            |
+    | tenant       | <dbl>   | number of tenants per square foot                  |
+    | recapture    | <dbl>   | recapture rate for rental income                   |
+    | sc           | <sc>    | supply-chain multiplier for business income losses |
+
+In addition, parameter values for sensitivity analysis should be
+provided under the sub-list `input_param$parameters$sensitivity`. For
+example, sensitivity analysis for `delta` would be conducted based on
+provided values `input_param$parameters$sensitivity$delta$low` and
+`input_param$parameters$sensitivity$delta$high`.
+
 ## Example
 
 This is a basic example which shows you how to solve a common problem:
 
 ``` r
+## NOT RUN
 library(frbca)
-## basic example code
+
+## assuming input data is loaded and parameters are set...
+
+## run analysis
+output <- frbca::frbca(input_eal, input_cost, input_param)
+
+## generate results plot with sensitivity analysis
+frbca::plot_frbca(output, n_floors=4, system='RCMF')
 ```

--- a/README.md
+++ b/README.md
@@ -35,43 +35,43 @@ form:
 
 Each row is an archetype model. Expected (minimum) columns:
 
-    | variable                 | type  | description                        |
-    |--------------------------|-------|------------------------------------|
-    | model                    | <chr> | unique model name or id            |
-    | intervention             | {0,1} | baseline design = 0; otherwise = 1 |
-    | num_stories              | <dbl> | number of stories                  |
-    | loss_ratio               | <dbl> | loss ratio                         |
-    | repair_costs             | <dbl> | repair costs, in dollars           |
-    | re_occupancy_time        | <dbl> | re-occupancy time, in days         |
-    | functional_recovery_time | <dbl> | functional recovery time, in days  |
+| variable                 | type  | description                        |
+|--------------------------|-------|------------------------------------|
+| model                    | <chr> | unique model name or id            |
+| intervention             | {0,1} | baseline design = 0; otherwise = 1 |
+| num_stories              | <dbl> | number of stories                  |
+| loss_ratio               | <dbl> | loss ratio                         |
+| repair_costs             | <dbl> | repair costs, in dollars           |
+| re_occupancy_time        | <dbl> | re-occupancy time, in days         |
+| functional_recovery_time | <dbl> | functional recovery time, in days  |
 
 ### Construction costs, for each archetype
 
 Each row is an archetype model. Expected (minimum) columns:
 
-    | variable     | type  | description                                  |
-    |--------------|-------|----------------------------------------------|
-    | model        | <chr> | unique model name or id                      |
-    | intervention | {0,1} | baseline design = 0; otherwise = 1           |
-    | num_stories  | <dbl> | number of stories                            |
-    | c_s          | <dbl> | structural construction costs, in dollars    |
-    | c_ns         | <dbl> | nonstructural construction costs, in dollars |
+| variable     | type  | description                                  |
+|--------------|-------|----------------------------------------------|
+| model        | <chr> | unique model name or id                      |
+| intervention | {0,1} | baseline design = 0; otherwise = 1           |
+| num_stories  | <dbl> | number of stories                            |
+| c_s          | <dbl> | structural construction costs, in dollars    |
+| c_ns         | <dbl> | nonstructural construction costs, in dollars |
 
 In addition, several parameters are required in list form. The following
 are the base parameters required under sub-list
 `input_param$parameters$base`:
 
-    | parameter    | type    | description                                        |
-    |--------------|---------|----------------------------------------------------|
-    | floor_area   | <dbl>   | total square footage per story                     |
-    | delta        | <delta> | discount rate                                      |
-    | T            | <dbl>   | planning horizon, in years                         |
-    | bi           | <dbl>   | business income                                    |
-    | ri           | <dbl>   | rental income                                      |
-    | displacement | <dbl>   | occupant-incurred costs of displacement            |
-    | tenant       | <dbl>   | number of tenants per square foot                  |
-    | recapture    | <dbl>   | recapture rate for rental income                   |
-    | sc           | <sc>    | supply-chain multiplier for business income losses |
+| parameter    | type    | description                                        |
+|--------------|---------|----------------------------------------------------|
+| floor_area   | <dbl>   | total square footage per story                     |
+| delta        | <delta> | discount rate                                      |
+| T            | <dbl>   | planning horizon, in years                         |
+| bi           | <dbl>   | business income                                    |
+| ri           | <dbl>   | rental income                                      |
+| displacement | <dbl>   | occupant-incurred costs of displacement            |
+| tenant       | <dbl>   | number of tenants per square foot                  |
+| recapture    | <dbl>   | recapture rate for rental income                   |
+| sc           | <sc>    | supply-chain multiplier for business income losses |
 
 In addition, parameter values for sensitivity analysis should be
 provided under the sub-list `input_param$parameters$sensitivity`. For


### PR DESCRIPTION
Modifies code to use explicit `num_stories` as input (rather than inferring from model name) and provides instructions on expected inputs in README. 

This resolves #1 and #2